### PR TITLE
Fix Docker build: Update Rust version from 1.75 to 1.83

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM rust:1.75-slim as builder
+FROM rust:1.83-slim as builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Update base image to rust:1.83-slim to support edition2024 feature required by dependencies like base64ct-1.8.1. This resolves the build error: 'feature edition2024 is required'.