### PR TITLE
Pin base64ct to v1.6.0 for Rust 1.83 compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,7 @@ dotenvy = "0.15"
 
 # UUID for session management
 uuid = { version = "1.0", features = ["v4", "serde"] }
+
+# Pin base64ct to version compatible with Rust 1.83
+[dependencies.base64ct]
+version = "=1.6.0"


### PR DESCRIPTION
Fix Docker build error by constraining base64ct to version 1.6.0 which is compatible with Rust 1.83. The newer v1.8.1 requires edition2024 feature which needs Rust 1.85+.

This resolves: 'feature edition2024 is required' build error