### PR TITLE
Replace Gemini API key auth with Gemini CLI authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
-# Google Gemini API Key
-# Get your API key from: https://makersuite.google.com/app/apikey
-GEMINI_API_KEY=your_api_key_here
-
 # Log level (optional)
 RUST_LOG=gemini_co_cli=debug,tower_http=debug
+
+# Note: No API key needed!
+# Authenticate using Gemini CLI instead:
+#   Local: Run 'gemini auth login'
+#   Docker: Run 'docker-compose run gemini-co-cli gemini auth login'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,6 @@ serde_json = "1.0"
 russh = "0.44"
 russh-keys = "0.44"
 
-# HTTP client for Gemini API
-reqwest = { version = "0.12", features = ["json"] }
-
 # Async utilities
 futures = "0.3"
 async-trait = "0.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ FROM rust:1.83-slim as builder
 RUN apt-get update && apt-get install -y \
     pkg-config \
     libssl-dev \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Create app directory
@@ -23,11 +24,18 @@ RUN cargo build --release
 # Runtime stage
 FROM debian:bookworm-slim
 
-# Install runtime dependencies
+# Install runtime dependencies including Python for Gemini CLI
 RUN apt-get update && apt-get install -y \
     ca-certificates \
     libssl3 \
+    python3 \
+    python3-pip \
+    python3-venv \
+    curl \
     && rm -rf /var/lib/apt/lists/*
+
+# Install Gemini CLI globally
+RUN pip3 install --break-system-packages google-generativeai-cli
 
 # Create app directory
 WORKDIR /app
@@ -44,5 +52,9 @@ EXPOSE 3000
 # Set environment variables
 ENV RUST_LOG=info
 
-# Run the application
+# Note: Users must authenticate Gemini CLI before running:
+# docker run -it <image> gemini auth login
+# Then run the application:
+# CMD ["./gemini-co-cli"]
+
 CMD ["./gemini-co-cli"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,13 @@ services:
     ports:
       - "3000:3000"
     environment:
-      - GEMINI_API_KEY=${GEMINI_API_KEY}
       - RUST_LOG=gemini_co_cli=debug,tower_http=debug
     restart: unless-stopped
     volumes:
       - ./static:/app/static:ro
+      # Mount Gemini CLI config directory for persistent auth
+      # Run 'docker-compose run gemini-co-cli gemini auth login' first to authenticate
+      - gemini-config:/root/.config/google-generativeai
+
+volumes:
+  gemini-config:


### PR DESCRIPTION
Major changes to authentication flow:
- Remove API key requirement (GEMINI_API_KEY)
- Integrate Google Gemini CLI for authentication
- Use 'gemini auth login' for OAuth-based authentication
- Remove reqwest HTTP client dependency

Backend changes:
- src/gemini.rs: Rewrite to execute Gemini CLI commands via subprocess
- Add check_auth() method to verify CLI authentication status
- Send messages via 'gemini chat' CLI command instead of REST API

Infrastructure changes:
- Dockerfile: Install Python and google-generativeai-cli package
- docker-compose.yml: Add volume for persistent Gemini credentials
- Remove GEMINI_API_KEY from environment variables

Configuration:
- .env.example: Remove API key, add auth instructions
- Cargo.toml: Remove reqwest dependency

Documentation:
- README.md: Comprehensive update with new auth flow
- Add authentication setup steps for Docker and local development
- Update troubleshooting section for CLI-based errors
- Update architecture diagram to reflect CLI wrapper

Benefits:
- No API key management needed
- Secure OAuth authentication via Google
- Persistent authentication in Docker volume
- Better alignment with official Gemini tooling