### PR TITLE
Fix Docker build: Add custom Gemini CLI wrapper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,13 @@
 # Log level (optional)
 RUST_LOG=gemini_co_cli=debug,tower_http=debug
 
-# Note: No API key needed!
-# Authenticate using Gemini CLI instead:
-#   Local: Run 'gemini auth login'
-#   Docker: Run 'docker-compose run gemini-co-cli gemini auth login'
+# Google Gemini API Key (Optional - if not using OAuth)
+# Get your API key from: https://makersuite.google.com/app/apikey
+# GOOGLE_API_KEY=your_api_key_here
+
+# Authentication Options:
+# 1. API Key (Simpler): Set GOOGLE_API_KEY above and run 'gemini auth login'
+# 2. OAuth (More Secure): Run 'gemini auth login' and follow browser prompts
+#
+# Docker: docker-compose run gemini-co-cli gemini auth login
+# Local:  gemini auth login (or python3 scripts/gemini-cli.py auth login)

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ RUN apt-get update && apt-get install -y \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Gemini CLI globally
-RUN pip3 install --break-system-packages google-generativeai-cli
+# Install Google Generative AI SDK
+RUN pip3 install --break-system-packages google-generativeai google-auth-oauthlib
 
 # Create app directory
 WORKDIR /app
@@ -46,15 +46,23 @@ COPY --from=builder /app/target/release/gemini-co-cli .
 # Copy static files
 COPY --from=builder /app/static ./static
 
+# Copy and install Gemini CLI wrapper
+COPY scripts/gemini-cli.py /usr/local/bin/gemini-cli.py
+RUN chmod +x /usr/local/bin/gemini-cli.py && \
+    ln -s /usr/local/bin/gemini-cli.py /usr/local/bin/gemini
+
 # Expose port
 EXPOSE 3000
 
 # Set environment variables
 ENV RUST_LOG=info
+ENV PATH="/usr/local/bin:${PATH}"
 
 # Note: Users must authenticate Gemini CLI before running:
-# docker run -it <image> gemini auth login
-# Then run the application:
-# CMD ["./gemini-co-cli"]
+# Option 1 - API Key (simpler):
+#   docker run -e GOOGLE_API_KEY=your_key <image> gemini auth login
+# Option 2 - OAuth (more secure):
+#   Place credentials.json in ~/.config/gemini-co-cli/ and run:
+#   docker run -it <image> gemini auth login
 
 CMD ["./gemini-co-cli"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,12 +7,14 @@ services:
       - "3000:3000"
     environment:
       - RUST_LOG=gemini_co_cli=debug,tower_http=debug
+      # Option 1: Use API key (uncomment and set your key)
+      # - GOOGLE_API_KEY=${GOOGLE_API_KEY}
+      # Option 2: Use OAuth (default - requires running 'gemini auth login' first)
     restart: unless-stopped
     volumes:
       - ./static:/app/static:ro
       # Mount Gemini CLI config directory for persistent auth
-      # Run 'docker-compose run gemini-co-cli gemini auth login' first to authenticate
-      - gemini-config:/root/.config/google-generativeai
+      - gemini-config:/root/.config/gemini-co-cli
 
 volumes:
   gemini-config:

--- a/scripts/gemini-cli.py
+++ b/scripts/gemini-cli.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""
+Gemini CLI wrapper for Gemini Co-CLI application.
+Provides a simple command-line interface to Google's Gemini API using OAuth authentication.
+"""
+
+import sys
+import os
+import argparse
+import json
+from pathlib import Path
+
+try:
+    import google.generativeai as genai
+    from google.auth.transport.requests import Request
+    from google.oauth2.credentials import Credentials
+    from google_auth_oauthlib.flow import InstalledAppFlow
+except ImportError:
+    print("Error: Required packages not installed. Run: pip install google-generativeai google-auth-oauthlib", file=sys.stderr)
+    sys.exit(1)
+
+# OAuth scopes for Gemini API
+SCOPES = ['https://www.googleapis.com/auth/generative-language.retriever']
+
+# Credentials storage location
+CONFIG_DIR = Path.home() / '.config' / 'gemini-co-cli'
+CREDS_FILE = CONFIG_DIR / 'credentials.json'
+TOKEN_FILE = CONFIG_DIR / 'token.json'
+
+
+def get_credentials():
+    """Get or refresh OAuth credentials."""
+    creds = None
+
+    # Check if we have stored credentials
+    if TOKEN_FILE.exists():
+        creds = Credentials.from_authorized_user_file(str(TOKEN_FILE), SCOPES)
+
+    # If no valid credentials, authenticate
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            try:
+                creds.refresh(Request())
+            except Exception as e:
+                print(f"Error refreshing credentials: {e}", file=sys.stderr)
+                print("Please run 'gemini-cli auth login' again", file=sys.stderr)
+                return None
+        else:
+            if not CREDS_FILE.exists():
+                print("Error: No credentials.json file found.", file=sys.stderr)
+                print(f"Please place your OAuth client credentials at: {CREDS_FILE}", file=sys.stderr)
+                print("Or use API key authentication instead.", file=sys.stderr)
+                return None
+
+            try:
+                flow = InstalledAppFlow.from_client_secrets_file(str(CREDS_FILE), SCOPES)
+                creds = flow.run_local_server(port=0)
+            except Exception as e:
+                print(f"Error during authentication: {e}", file=sys.stderr)
+                return None
+
+        # Save credentials for next time
+        CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        with open(TOKEN_FILE, 'w') as token:
+            token.write(creds.to_json())
+
+    return creds
+
+
+def auth_login():
+    """Authenticate with Google account."""
+    print("Authenticating with Google Gemini...")
+    print(f"Note: For OAuth authentication, place your credentials.json file at: {CREDS_FILE}")
+    print("Alternatively, set GOOGLE_API_KEY environment variable for API key authentication.")
+
+    # Check for API key first
+    api_key = os.environ.get('GOOGLE_API_KEY')
+    if api_key:
+        print("Using API key authentication from GOOGLE_API_KEY environment variable")
+        CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        with open(CONFIG_DIR / 'api_key.txt', 'w') as f:
+            f.write(api_key)
+        print("✓ API key stored successfully")
+        return
+
+    # Try OAuth
+    creds = get_credentials()
+    if creds:
+        print("✓ Authentication successful!")
+    else:
+        print("✗ Authentication failed", file=sys.stderr)
+        sys.exit(1)
+
+
+def auth_status():
+    """Check authentication status."""
+    # Check for API key
+    api_key_file = CONFIG_DIR / 'api_key.txt'
+    if api_key_file.exists():
+        print("Authenticated with API key")
+        return True
+
+    # Check for OAuth token
+    if TOKEN_FILE.exists():
+        try:
+            creds = Credentials.from_authorized_user_file(str(TOKEN_FILE), SCOPES)
+            if creds and creds.valid:
+                print("Authenticated with OAuth")
+                return True
+            elif creds and creds.expired:
+                print("OAuth token expired - will refresh on next use")
+                return True
+        except Exception:
+            pass
+
+    print("Not authenticated", file=sys.stderr)
+    return False
+
+
+def chat(prompt, model='gemini-1.5-pro'):
+    """Send a chat message to Gemini."""
+    # Try API key first
+    api_key_file = CONFIG_DIR / 'api_key.txt'
+    if api_key_file.exists():
+        with open(api_key_file, 'r') as f:
+            api_key = f.read().strip()
+        genai.configure(api_key=api_key)
+    else:
+        # Try OAuth
+        creds = get_credentials()
+        if not creds:
+            print("Error: Not authenticated. Run 'gemini-cli auth login' first", file=sys.stderr)
+            sys.exit(1)
+        genai.configure(credentials=creds)
+
+    try:
+        model_obj = genai.GenerativeModel(model)
+        response = model_obj.generate_content(prompt)
+        print(response.text)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main():
+    """Main CLI entry point."""
+    parser = argparse.ArgumentParser(description='Gemini CLI wrapper')
+    subparsers = parser.add_subparsers(dest='command', help='Commands')
+
+    # Auth commands
+    auth_parser = subparsers.add_parser('auth', help='Authentication commands')
+    auth_subparsers = auth_parser.add_subparsers(dest='auth_command')
+    auth_subparsers.add_parser('login', help='Authenticate with Google')
+    auth_subparsers.add_parser('status', help='Check authentication status')
+
+    # Chat command
+    chat_parser = subparsers.add_parser('chat', help='Send a chat message')
+    chat_parser.add_argument('--model', default='gemini-1.5-pro', help='Model to use')
+    chat_parser.add_argument('--prompt', required=True, help='Prompt to send')
+
+    args = parser.parse_args()
+
+    if args.command == 'auth':
+        if args.auth_command == 'login':
+            auth_login()
+        elif args.auth_command == 'status':
+            if auth_status():
+                sys.exit(0)
+            else:
+                sys.exit(1)
+        else:
+            auth_parser.print_help()
+    elif args.command == 'chat':
+        chat(args.prompt, args.model)
+    else:
+        parser.print_help()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The package 'google-generativeai-cli' does not exist in PyPI. Created a custom Python CLI wrapper that uses the official google-generativeai SDK.

Changes:
- scripts/gemini-cli.py: New Python CLI wrapper for Gemini API
  - Supports both API key and OAuth authentication
  - Commands: auth login, auth status, chat
  - Stores credentials in ~/.config/gemini-co-cli/

- Dockerfile: Install correct packages
  - Use google-generativeai and google-auth-oauthlib
  - Copy and symlink gemini-cli.py to /usr/local/bin/gemini
  - Add comments for both auth methods

- docker-compose.yml: Update volume path
  - Changed from google-generativeai to gemini-co-cli
  - Add comment for GOOGLE_API_KEY option

- .env.example: Document both auth methods
  - Add GOOGLE_API_KEY option
  - Clear instructions for API key vs OAuth

- README.md: Complete rewrite of auth section
  - Two authentication options: API key (recommended) and OAuth
  - Step-by-step guides for both Docker and local setup
  - Updated troubleshooting section
  - Added scripts directory to project structure

Authentication flow:
1. API Key: Set GOOGLE_API_KEY env var, run 'gemini auth login'
2. OAuth: Set up OAuth credentials, run 'gemini auth login' for browser flow

This resolves the Docker build error and provides a working Gemini authentication system.