### PR TITLE
Implement dual-terminal architecture with interactive Gemini CLI

### DIFF
--- a/src/gemini.rs
+++ b/src/gemini.rs
@@ -1,102 +1,78 @@
 use anyhow::{Context, Result};
-use tokio::process::Command;
+use std::process::Stdio;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio::sync::mpsc;
 
-pub struct GeminiClient {
-    model: String,
+/// Manages an interactive Gemini CLI terminal session
+pub struct GeminiTerminal {
+    process: Child,
 }
 
-impl GeminiClient {
-    pub fn new() -> Result<Self> {
-        // Uses official @google/gemini-cli
-        // Authentication via GEMINI_API_KEY env var or interactive OAuth
-        Ok(Self {
-            model: "gemini-1.5-pro".to_string(),
-        })
+impl GeminiTerminal {
+    /// Spawn a new interactive Gemini CLI process
+    pub async fn spawn() -> Result<Self> {
+        let process = Command::new("gemini")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .context("Failed to spawn gemini CLI. Is it installed?")?;
+
+        Ok(Self { process })
     }
 
-    /// Check if Gemini CLI is available and authenticated
-    /// Note: Official CLI doesn't have an explicit auth status command
-    /// We check by attempting a simple query
-    pub async fn check_auth() -> Result<bool> {
-        let output = Command::new("gemini")
-            .arg("-p")
-            .arg("Hello")
-            .arg("--output-format")
-            .arg("json")
-            .output()
+    /// Get stdin handle for writing to Gemini
+    pub fn stdin(&mut self) -> Option<tokio::process::ChildStdin> {
+        self.process.stdin.take()
+    }
+
+    /// Get stdout handle for reading from Gemini
+    pub fn stdout(&mut self) -> Option<tokio::process::ChildStdout> {
+        self.process.stdout.take()
+    }
+
+    /// Get stderr handle for reading errors
+    pub fn stderr(&mut self) -> Option<tokio::process::ChildStderr> {
+        self.process.stderr.take()
+    }
+
+    /// Kill the Gemini process
+    pub async fn kill(mut self) -> Result<()> {
+        self.process
+            .kill()
             .await
-            .context("Failed to check Gemini CLI. Is it installed?")?;
-
-        Ok(output.status.success())
+            .context("Failed to kill gemini process")?;
+        Ok(())
     }
+}
 
-    pub async fn send_message(
-        &self,
-        user_message: String,
-        context: Vec<String>,
-    ) -> Result<String> {
-        // Build the prompt with context
-        let mut full_prompt = String::new();
-
-        if !context.is_empty() {
-            full_prompt.push_str("Terminal Context (recent output):\n```\n");
-            for ctx in context.iter().rev().take(20).rev() {
-                full_prompt.push_str(&format!("{}\n", ctx));
-            }
-            full_prompt.push_str("```\n\n");
+/// Parse Gemini output for EXECUTE commands
+pub fn extract_command(text: &str) -> Option<String> {
+    // Look for "EXECUTE: <command>" pattern
+    if let Some(pos) = text.find("EXECUTE:") {
+        let command_part = &text[pos + 8..];
+        let command = command_part.lines().next().unwrap_or("").trim().to_string();
+        if !command.is_empty() {
+            return Some(command);
         }
-
-        full_prompt.push_str(&format!(
-            "{}\n\nIMPORTANT: If you want to execute a command in the terminal, format it as: EXECUTE: <command>",
-            user_message
-        ));
-
-        // Execute gemini with non-interactive prompt
-        // Official CLI syntax: gemini -p "prompt" -m model-name
-        let output = Command::new("gemini")
-            .arg("-p")
-            .arg(&full_prompt)
-            .arg("-m")
-            .arg(&self.model)
-            .output()
-            .await
-            .context("Failed to execute gemini CLI. Ensure it's installed and authenticated.")?;
-
-        if !output.status.success() {
-            let error = String::from_utf8_lossy(&output.stderr);
-            return Err(anyhow::anyhow!(
-                "Gemini CLI error: {}. Authentication required. Set GEMINI_API_KEY or run 'docker run -it <container> gemini' to login with Google.",
-                error
-            ));
-        }
-
-        let response = String::from_utf8_lossy(&output.stdout).to_string();
-
-        // Clean up the response (remove any CLI formatting)
-        let cleaned_response = response.trim().to_string();
-
-        if cleaned_response.is_empty() {
-            return Err(anyhow::anyhow!("Empty response from Gemini CLI"));
-        }
-
-        Ok(cleaned_response)
     }
+    None
+}
 
-    /// Extract command from Gemini response if present
-    pub fn extract_command(response: &str) -> Option<String> {
-        if let Some(pos) = response.find("EXECUTE:") {
-            let command_part = &response[pos + 8..];
-            let command = command_part
-                .lines()
-                .next()
-                .unwrap_or("")
-                .trim()
-                .to_string();
-            if !command.is_empty() {
-                return Some(command);
-            }
+/// Monitor Gemini output for commands and send them to a channel
+pub async fn monitor_for_commands(
+    mut stdout: tokio::process::ChildStdout,
+    tx: mpsc::UnboundedSender<String>,
+) {
+    let reader = BufReader::new(&mut stdout);
+    let mut lines = reader.lines();
+
+    while let Ok(Some(line)) = lines.next_line().await {
+        // Check each line for EXECUTE commands
+        if let Some(command) = extract_command(&line) {
+            let _ = tx.send(command);
         }
-        None
     }
 }
 
@@ -106,13 +82,13 @@ mod tests {
 
     #[test]
     fn test_extract_command() {
-        let response = "I'll help you with that. EXECUTE: ls -la";
-        assert_eq!(
-            GeminiClient::extract_command(response),
-            Some("ls -la".to_string())
-        );
+        let text = "Sure! EXECUTE: ls -la";
+        assert_eq!(extract_command(text), Some("ls -la".to_string()));
 
-        let response_no_cmd = "I'll help you with that.";
-        assert_eq!(GeminiClient::extract_command(response_no_cmd), None);
+        let text_no_cmd = "Here's some help text";
+        assert_eq!(extract_command(text_no_cmd), None);
+
+        let text_multiline = "I recommend:\nEXECUTE: pwd";
+        assert_eq!(extract_command(text_multiline), Some("pwd".to_string()));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,9 +36,11 @@ async fn main() {
     // Build the application routes
     let app = Router::new()
         .route("/", get(root_handler))
+        .route("/api/session/create", post(websocket::create_session_handler))
         .route("/api/ssh/connect", post(websocket::ssh_connect_handler))
-        .route("/ws/terminal/:session_id", get(websocket::terminal_ws_handler))
-        .route("/ws/gemini/:session_id", get(websocket::gemini_ws_handler))
+        .route("/ws/gemini-terminal/:session_id", get(websocket::gemini_terminal_ws_handler))
+        .route("/ws/ssh-terminal/:session_id", get(websocket::ssh_terminal_ws_handler))
+        .route("/ws/commands/:session_id", get(websocket::command_approval_ws_handler))
         .nest_service("/static", ServeDir::new("static"))
         .layer(TraceLayer::new_for_http())
         .with_state(app_state);

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -9,12 +9,24 @@ use axum::{
 use futures::{sink::SinkExt, stream::StreamExt};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use tokio::sync::Mutex;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::sync::{mpsc, Mutex};
 use uuid::Uuid;
 
-use crate::gemini::GeminiClient;
+use crate::gemini::{extract_command, GeminiTerminal};
 use crate::ssh::{SshConfig, SshSession};
 use crate::state::AppState;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SessionRequest {
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SessionResponse {
+    pub session_id: String,
+    pub success: bool,
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SshConnectRequest {
@@ -43,13 +55,18 @@ pub enum TerminalMessage {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
-pub enum GeminiWsMessage {
-    UserMessage { content: String },
-    GeminiResponse { content: String },
+pub enum CommandMessage {
     CommandRequest { command: String, command_id: String },
     CommandApproval { command_id: String, approved: bool },
-    CommandExecuted { command: String, output: String },
-    Error { message: String },
+}
+
+/// Create a new session
+pub async fn create_session_handler(State(state): State<AppState>) -> Json<SessionResponse> {
+    let session = state.create_session().await;
+    Json(SessionResponse {
+        session_id: session.id.to_string(),
+        success: true,
+    })
 }
 
 /// Handle SSH connection request
@@ -57,7 +74,7 @@ pub async fn ssh_connect_handler(
     State(state): State<AppState>,
     Json(request): Json<SshConnectRequest>,
 ) -> Json<ConnectResponse> {
-    // Create a new session
+    // Create session
     let session = state.create_session().await;
 
     // Attempt to connect via SSH
@@ -96,16 +113,165 @@ pub async fn ssh_connect_handler(
     }
 }
 
-/// Handle terminal WebSocket connection
-pub async fn terminal_ws_handler(
+/// Handle Gemini terminal WebSocket connection
+pub async fn gemini_terminal_ws_handler(
     ws: WebSocketUpgrade,
     Path(session_id): Path<String>,
     State(state): State<AppState>,
 ) -> Response {
-    ws.on_upgrade(move |socket| terminal_ws_connection(socket, session_id, state))
+    ws.on_upgrade(move |socket| gemini_terminal_connection(socket, session_id, state))
 }
 
-async fn terminal_ws_connection(socket: WebSocket, session_id: String, state: AppState) {
+async fn gemini_terminal_connection(socket: WebSocket, session_id: String, state: AppState) {
+    let session_uuid = match Uuid::parse_str(&session_id) {
+        Ok(id) => id,
+        Err(_) => {
+            tracing::error!("Invalid session ID: {}", session_id);
+            return;
+        }
+    };
+
+    let session = match state.get_session(session_uuid).await {
+        Some(s) => s,
+        None => {
+            tracing::error!("Session not found: {}", session_id);
+            return;
+        }
+    };
+
+    // Spawn Gemini CLI process
+    let mut gemini = match GeminiTerminal::spawn().await {
+        Ok(g) => g,
+        Err(e) => {
+            tracing::error!("Failed to spawn Gemini CLI: {}", e);
+            return;
+        }
+    };
+
+    let (ws_sender, mut ws_receiver) = socket.split();
+    let ws_sender = Arc::new(Mutex::new(ws_sender));
+
+    // Get handles to Gemini process (take ownership)
+    let mut stdin = gemini.stdin().expect("Failed to get stdin");
+    let stdout = gemini.stdout().expect("Failed to get stdout");
+    let stderr = gemini.stderr().expect("Failed to get stderr");
+
+    // Channel for command requests from Gemini
+    let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel::<String>();
+
+    // Task to read from Gemini stdout and send to WebSocket
+    let ws_sender_clone = ws_sender.clone();
+    let mut stdout_task = tokio::spawn(async move {
+        let reader = BufReader::new(stdout);
+        let mut lines = reader.lines();
+
+        while let Ok(Some(line)) = lines.next_line().await {
+            // Check for EXECUTE commands
+            if let Some(command) = extract_command(&line) {
+                tracing::info!("Gemini suggested command: {}", command);
+                let _ = cmd_tx.send(command);
+            }
+
+            // Send output to WebSocket
+            let msg = TerminalMessage::Output { data: line + "\r\n" };
+            let json = serde_json::to_string(&msg).unwrap();
+            let mut sender = ws_sender_clone.lock().await;
+            if sender.send(Message::Text(json)).await.is_err() {
+                break;
+            }
+        }
+    });
+
+    // Task to read from Gemini stderr and send to WebSocket
+    let ws_sender_clone = ws_sender.clone();
+    let mut stderr_task = tokio::spawn(async move {
+        let reader = BufReader::new(stderr);
+        let mut lines = reader.lines();
+
+        while let Ok(Some(line)) = lines.next_line().await {
+            let msg = TerminalMessage::Error {
+                message: line.clone(),
+            };
+            let json = serde_json::to_string(&msg).unwrap();
+            let mut sender = ws_sender_clone.lock().await;
+            if sender.send(Message::Text(json)).await.is_err() {
+                break;
+            }
+        }
+    });
+
+    // Task to handle WebSocket input and send to Gemini stdin
+    let mut stdin_task = tokio::spawn(async move {
+        while let Some(Ok(msg)) = ws_receiver.next().await {
+            if let Message::Text(text) = msg {
+                if let Ok(terminal_msg) = serde_json::from_str::<TerminalMessage>(&text) {
+                    match terminal_msg {
+                        TerminalMessage::Input { data } => {
+                            if let Err(e) = stdin.write_all(data.as_bytes()).await {
+                                tracing::error!("Error writing to Gemini stdin: {}", e);
+                                break;
+                            }
+                            let _ = stdin.flush().await;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+    });
+
+    // Task to handle command approvals and execute on SSH terminal
+    let session_clone = session.clone();
+    let mut cmd_task = tokio::spawn(async move {
+        while let Some(command) = cmd_rx.recv().await {
+            // Add to pending commands
+            let cmd_id = session_clone.add_pending_command(command.clone()).await;
+
+            tracing::info!("Command pending approval: {} (ID: {})", command, cmd_id);
+
+            // In a real implementation, we'd wait for approval through another WebSocket message
+            // For now, commands need to be approved via the command approval WebSocket
+        }
+    });
+
+    // Wait for tasks to complete
+    tokio::select! {
+        _ = &mut stdout_task => {
+            stderr_task.abort();
+            stdin_task.abort();
+            cmd_task.abort();
+        }
+        _ = &mut stderr_task => {
+            stdout_task.abort();
+            stdin_task.abort();
+            cmd_task.abort();
+        }
+        _ = &mut stdin_task => {
+            stdout_task.abort();
+            stderr_task.abort();
+            cmd_task.abort();
+        }
+        _ = &mut cmd_task => {
+            stdout_task.abort();
+            stderr_task.abort();
+            stdin_task.abort();
+        }
+    };
+
+    // Clean up
+    let _ = gemini.kill().await;
+}
+
+/// Handle SSH terminal WebSocket connection
+pub async fn ssh_terminal_ws_handler(
+    ws: WebSocketUpgrade,
+    Path(session_id): Path<String>,
+    State(state): State<AppState>,
+) -> Response {
+    ws.on_upgrade(move |socket| ssh_terminal_connection(socket, session_id, state))
+}
+
+async fn ssh_terminal_connection(socket: WebSocket, session_id: String, state: AppState) {
     let session_uuid = match Uuid::parse_str(&session_id) {
         Ok(id) => id,
         Err(_) => {
@@ -135,8 +301,8 @@ async fn terminal_ws_connection(socket: WebSocket, session_id: String, state: Ap
             loop {
                 match ssh_guard.read_output().await {
                     Ok(Some(output)) => {
-                        // Add to session history
-                        session_clone.add_terminal_output(output.clone()).await;
+                        // Add to session's SSH output buffer
+                        session_clone.add_ssh_output(output.clone()).await;
 
                         // Send to WebSocket
                         let msg = TerminalMessage::Output { data: output };
@@ -199,16 +365,16 @@ async fn terminal_ws_connection(socket: WebSocket, session_id: String, state: Ap
     };
 }
 
-/// Handle Gemini WebSocket connection
-pub async fn gemini_ws_handler(
+/// Handle command approval WebSocket
+pub async fn command_approval_ws_handler(
     ws: WebSocketUpgrade,
     Path(session_id): Path<String>,
     State(state): State<AppState>,
 ) -> Response {
-    ws.on_upgrade(move |socket| gemini_ws_connection(socket, session_id, state))
+    ws.on_upgrade(move |socket| command_approval_connection(socket, session_id, state))
 }
 
-async fn gemini_ws_connection(socket: WebSocket, session_id: String, state: AppState) {
+async fn command_approval_connection(socket: WebSocket, session_id: String, state: AppState) {
     let session_uuid = match Uuid::parse_str(&session_id) {
         Ok(id) => id,
         Err(_) => {
@@ -225,82 +391,60 @@ async fn gemini_ws_connection(socket: WebSocket, session_id: String, state: AppS
         }
     };
 
-    let gemini_client = match GeminiClient::new() {
-        Ok(client) => Arc::new(client),
-        Err(e) => {
-            tracing::error!("Failed to create Gemini client: {}", e);
-            return;
-        }
-    };
-
     let (mut sender, mut receiver) = socket.split();
 
-    // Handle incoming messages from WebSocket
-    while let Some(Ok(msg)) = receiver.next().await {
-        if let Message::Text(text) = msg {
-            if let Ok(ws_msg) = serde_json::from_str::<GeminiWsMessage>(&text) {
-                match ws_msg {
-                    GeminiWsMessage::UserMessage { content } => {
-                        // Get terminal context
-                        let context = session.get_context().await;
+    // Monitor pending commands and send to WebSocket
+    let session_clone = session.clone();
+    let mut monitor_task = tokio::spawn(async move {
+        loop {
+            let pending = session_clone.pending_commands.lock().await;
+            for cmd in pending.iter() {
+                if !cmd.approved {
+                    let msg = CommandMessage::CommandRequest {
+                        command: cmd.command.clone(),
+                        command_id: cmd.id.to_string(),
+                    };
+                    let json = serde_json::to_string(&msg).unwrap();
+                    let _ = sender.send(Message::Text(json)).await;
+                }
+            }
+            drop(pending);
+            tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+        }
+    });
 
-                        // Send to Gemini
-                        match gemini_client.send_message(content, context).await {
-                            Ok(response) => {
-                                // Check if Gemini wants to execute a command
-                                if let Some(command) = GeminiClient::extract_command(&response) {
-                                    // Request user approval
-                                    let cmd_id = session.add_pending_command(command.clone()).await;
-
-                                    let msg = GeminiWsMessage::CommandRequest {
-                                        command,
-                                        command_id: cmd_id.to_string(),
-                                    };
-                                    let json = serde_json::to_string(&msg).unwrap();
-                                    let _ = sender.send(Message::Text(json)).await;
-                                } else {
-                                    // Send response without command
-                                    let msg = GeminiWsMessage::GeminiResponse {
-                                        content: response,
-                                    };
-                                    let json = serde_json::to_string(&msg).unwrap();
-                                    let _ = sender.send(Message::Text(json)).await;
-                                }
-                            }
-                            Err(e) => {
-                                let msg = GeminiWsMessage::Error {
-                                    message: e.to_string(),
-                                };
-                                let json = serde_json::to_string(&msg).unwrap();
-                                let _ = sender.send(Message::Text(json)).await;
-                            }
-                        }
-                    }
-                    GeminiWsMessage::CommandApproval {
-                        command_id,
-                        approved,
-                    } => {
-                        if approved {
-                            let cmd_uuid = Uuid::parse_str(&command_id).unwrap();
-                            if let Some(command) = session.approve_command(cmd_uuid).await {
-                                // Execute the command via SSH
-                                if let Some(ssh) = &session.ssh_session {
-                                    let mut ssh_guard = ssh.lock().await;
-                                    if let Err(e) = ssh_guard.execute_command(command.clone()).await
-                                    {
-                                        let msg = GeminiWsMessage::Error {
-                                            message: format!("Failed to execute command: {}", e),
-                                        };
-                                        let json = serde_json::to_string(&msg).unwrap();
-                                        let _ = sender.send(Message::Text(json)).await;
+    // Handle command approvals
+    let mut recv_task = tokio::spawn(async move {
+        while let Some(Ok(msg)) = receiver.next().await {
+            if let Message::Text(text) = msg {
+                if let Ok(cmd_msg) = serde_json::from_str::<CommandMessage>(&text) {
+                    match cmd_msg {
+                        CommandMessage::CommandApproval {
+                            command_id,
+                            approved,
+                        } => {
+                            if approved {
+                                let cmd_uuid = Uuid::parse_str(&command_id).unwrap();
+                                if let Some(command) = session.approve_command(cmd_uuid).await {
+                                    // Execute on SSH terminal
+                                    if let Some(ssh) = &session.ssh_session {
+                                        let mut ssh_guard = ssh.lock().await;
+                                        if let Err(e) = ssh_guard.execute_command(command).await {
+                                            tracing::error!("Error executing approved command: {}", e);
+                                        }
                                     }
                                 }
                             }
                         }
+                        _ => {}
                     }
-                    _ => {}
                 }
             }
         }
-    }
+    });
+
+    tokio::select! {
+        _ = &mut monitor_task => recv_task.abort(),
+        _ = &mut recv_task => monitor_task.abort(),
+    };
 }

--- a/static/index.html
+++ b/static/index.html
@@ -49,22 +49,18 @@
         <div class="split-container">
             <div class="pane gemini-pane">
                 <div class="pane-header">
-                    <h2>💬 Gemini Assistant</h2>
+                    <h2>🤖 Gemini CLI Terminal</h2>
                 </div>
-                <div id="gemini-chat" class="chat-container"></div>
-                <div class="input-container">
-                    <textarea id="gemini-input" placeholder="Ask Gemini anything about your terminal..." rows="3"></textarea>
-                    <button id="send-btn" class="btn-primary">Send</button>
-                </div>
+                <div id="gemini-terminal"></div>
             </div>
 
             <div class="resizer"></div>
 
             <div class="pane terminal-pane">
                 <div class="pane-header">
-                    <h2>💻 Terminal</h2>
+                    <h2>💻 SSH Terminal</h2>
                 </div>
-                <div id="terminal"></div>
+                <div id="ssh-terminal"></div>
             </div>
         </div>
     </div>

--- a/static/style.css
+++ b/static/style.css
@@ -246,7 +246,8 @@ body {
     border-color: #4ade80;
 }
 
-#terminal {
+#gemini-terminal,
+#ssh-terminal {
     flex: 1;
     padding: 1rem;
     overflow: hidden;


### PR DESCRIPTION
Architecture Changes:
- Replace Gemini chat interface with interactive Gemini CLI terminal
- Both panes now display full xterm.js terminals (Gemini left, SSH right)
- Three WebSocket connections: gemini-terminal, ssh-terminal, commands

Backend Updates:
- gemini.rs: Manage interactive Gemini CLI process with stdin/stdout/stderr
- websocket.rs: Three handlers for Gemini terminal, SSH terminal, and command approval
- state.rs: Track SSH output buffer and support cross-terminal communication
- main.rs: Updated routes for new WebSocket endpoints

Frontend Updates:
- index.html: Dual terminal UI (removed chat interface)
- app.js: Complete rewrite for two xterm.js terminals with WebSocket integration
- style.css: Updated styles for both terminal containers

Documentation:
- README.md: Updated architecture diagram, usage instructions, and API endpoints
- Reflect new dual-terminal workflow and command execution flow

This implements the user's request to run Gemini CLI as an interactive terminal in the browser's left panel with SSH terminal in the right panel, with Gemini able to read and write to the SSH terminal.