### PR TITLE
Fix terminal container height and visibility issues

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -131,6 +131,10 @@ function setupTerminals() {
 
         geminiTerminal.open(geminiContainer);
 
+        // Write initial message
+        geminiTerminal.write('\x1b[36mGemini CLI Terminal\x1b[0m\r\n');
+        geminiTerminal.write('Connecting to Gemini...\r\n\r\n');
+
         // Fit after a short delay to ensure DOM is ready
         setTimeout(() => {
             geminiFitAddon.fit();
@@ -171,6 +175,10 @@ function setupTerminals() {
         }
 
         sshTerminal.open(sshContainer);
+
+        // Write initial message
+        sshTerminal.write('\x1b[32mSSH Terminal\x1b[0m\r\n');
+        sshTerminal.write('Connecting to SSH server...\r\n\r\n');
 
         // Fit after a short delay to ensure DOM is ready
         setTimeout(() => {

--- a/static/style.css
+++ b/static/style.css
@@ -154,6 +154,7 @@ body {
     flex-direction: column;
     background: #1a1a1a;
     overflow: hidden;
+    height: 100%;
 }
 
 .gemini-pane {
@@ -249,10 +250,19 @@ body {
 #gemini-terminal,
 #ssh-terminal {
     flex: 1;
-    padding: 1rem;
+    padding: 0.5rem;
     overflow: hidden;
-    min-height: 400px;
     position: relative;
+    height: 100%;
+    /* Debug: show container boundaries */
+    background: #0a0a0a;
+}
+
+/* Ensure xterm.js terminal fills container */
+#gemini-terminal .xterm,
+#ssh-terminal .xterm {
+    height: 100%;
+    width: 100%;
 }
 
 .command-preview {


### PR DESCRIPTION
CSS Fixes:
- Add height: 100% to .pane class to participate in flex layout
- Add height: 100% to terminal containers
- Add width: 100% and height: 100% to .xterm elements
- Reduce padding from 1rem to 0.5rem for more terminal space
- Add background color to terminal containers for visibility

JavaScript Improvements:
- Add initial welcome messages to both terminals on open
- Gemini terminal shows "Gemini CLI Terminal" in cyan
- SSH terminal shows "SSH Terminal" in green
- Messages appear immediately to verify rendering

These changes fix the flex-direction: column layout where child elements with flex: 1 weren't expanding because parent didn't have defined height. Terminals should now be visible and fill the available space.