### PR TITLE
Fix flexbox layout conflicts preventing terminal rendering

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -131,6 +131,10 @@ function setupTerminals() {
 
         geminiTerminal.open(geminiContainer);
 
+        // Log container dimensions
+        const geminiRect = geminiContainer.getBoundingClientRect();
+        console.log('Gemini container dimensions:', geminiRect.width, 'x', geminiRect.height);
+
         // Write initial message
         geminiTerminal.write('\x1b[36mGemini CLI Terminal\x1b[0m\r\n');
         geminiTerminal.write('Connecting to Gemini...\r\n\r\n');
@@ -139,6 +143,11 @@ function setupTerminals() {
         setTimeout(() => {
             geminiFitAddon.fit();
             console.log('Gemini terminal fitted:', geminiTerminal.cols, 'x', geminiTerminal.rows);
+            const xtermElement = geminiContainer.querySelector('.xterm');
+            if (xtermElement) {
+                const xtermRect = xtermElement.getBoundingClientRect();
+                console.log('Gemini xterm element dimensions:', xtermRect.width, 'x', xtermRect.height);
+            }
         }, 100);
 
         // Handle Gemini terminal input
@@ -176,6 +185,10 @@ function setupTerminals() {
 
         sshTerminal.open(sshContainer);
 
+        // Log container dimensions
+        const sshRect = sshContainer.getBoundingClientRect();
+        console.log('SSH container dimensions:', sshRect.width, 'x', sshRect.height);
+
         // Write initial message
         sshTerminal.write('\x1b[32mSSH Terminal\x1b[0m\r\n');
         sshTerminal.write('Connecting to SSH server...\r\n\r\n');
@@ -184,6 +197,11 @@ function setupTerminals() {
         setTimeout(() => {
             sshFitAddon.fit();
             console.log('SSH terminal fitted:', sshTerminal.cols, 'x', sshTerminal.rows);
+            const xtermElement = sshContainer.querySelector('.xterm');
+            if (xtermElement) {
+                const xtermRect = xtermElement.getBoundingClientRect();
+                console.log('SSH xterm element dimensions:', xtermRect.width, 'x', xtermRect.height);
+            }
         }, 100);
 
         // Handle SSH terminal input
@@ -198,8 +216,15 @@ function setupTerminals() {
 
         // Handle window resize for both terminals
         window.addEventListener('resize', () => {
-            if (geminiFitAddon) geminiFitAddon.fit();
-            if (sshFitAddon) sshFitAddon.fit();
+            console.log('Window resized, refitting terminals...');
+            if (geminiFitAddon) {
+                geminiFitAddon.fit();
+                console.log('Gemini refitted:', geminiTerminal.cols, 'x', geminiTerminal.rows);
+            }
+            if (sshFitAddon) {
+                sshFitAddon.fit();
+                console.log('SSH refitted:', sshTerminal.cols, 'x', sshTerminal.rows);
+            }
 
             if (geminiTerminalWs && geminiTerminalWs.readyState === WebSocket.OPEN) {
                 geminiTerminalWs.send(JSON.stringify({

--- a/static/style.css
+++ b/static/style.css
@@ -154,7 +154,6 @@ body {
     flex-direction: column;
     background: #1a1a1a;
     overflow: hidden;
-    height: 100%;
 }
 
 .gemini-pane {
@@ -253,16 +252,8 @@ body {
     padding: 0.5rem;
     overflow: hidden;
     position: relative;
-    height: 100%;
     /* Debug: show container boundaries */
     background: #0a0a0a;
-}
-
-/* Ensure xterm.js terminal fills container */
-#gemini-terminal .xterm,
-#ssh-terminal .xterm {
-    height: 100%;
-    width: 100%;
 }
 
 .command-preview {


### PR DESCRIPTION
Root Cause:
Elements with both .pane and .gemini-pane classes were receiving conflicting styles: flex: 1 (from .gemini-pane) AND height: 100% (from .pane). This created a circular dependency in the flex layout where children couldn't determine their size.

CSS Fixes (style.css):
- Remove height: 100% from .pane class - let flex: 1 handle sizing
- Remove height: 100% from #gemini-terminal and #ssh-terminal
- Remove width/height from .xterm elements - not needed for flex
- Keep flex: 1 on all expanding elements for proper flex chain

The correct flex chain is:
#app-container (fixed height) ->
  .split-container (flex: 1) ->
    .pane.gemini-pane (flex: 1, flex-direction: column) ->       .pane-header (auto height)
      #gemini-terminal (flex: 1)

JavaScript Enhancements (app.js):
- Log container dimensions when terminals open
- Log terminal dimensions after fit()
- Log xterm element dimensions for debugging
- Add logging to window resize handler
- Add logging to terminal refit operations

This will help diagnose if containers have zero height or if terminals are rendering but invisible for other reasons.