### PR TITLE
Terminal Interactivity Fixes

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -8,86 +8,50 @@ let sshTerminal = null;
 let geminiFitAddon = null;
 let sshFitAddon = null;
 let pendingCommand = null;
+let sshConnected = false;
 
 // Initialize on page load
 document.addEventListener('DOMContentLoaded', () => {
-    setupSSHForm();
-    setupResizer();
+    initializeApp();
 });
 
-// Setup SSH connection form
-function setupSSHForm() {
-    const form = document.getElementById('ssh-form');
-    form.addEventListener('submit', async (e) => {
-        e.preventDefault();
+// Initialize the main application immediately
+async function initializeApp() {
+    try {
+        // Create a session
+        const response = await fetch('/api/session/create', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({}),
+        });
 
-        const formData = {
-            host: document.getElementById('host').value,
-            port: parseInt(document.getElementById('port').value),
-            username: document.getElementById('username').value,
-            password: document.getElementById('password').value || null,
-            private_key: document.getElementById('private-key').value || null,
-        };
-
-        try {
-            // First, create a session
-            const sessionResponse = await fetch('/api/session/create', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({}),
-            });
-
-            const sessionResult = await sessionResponse.json();
-            if (!sessionResult.success) {
-                showError('Failed to create session');
-                return;
-            }
-
-            sessionId = sessionResult.session_id;
-
-            // Then connect SSH
-            const sshResponse = await fetch('/api/ssh/connect', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify(formData),
-            });
-
-            const sshResult = await sshResponse.json();
-
-            if (sshResult.success) {
-                // Use the session ID from SSH connection if different
-                sessionId = sshResult.session_id;
-                hideConnectionModal();
-                initializeApp();
-            } else {
-                showError(sshResult.error || 'SSH connection failed');
-            }
-        } catch (error) {
-            showError('Failed to connect: ' + error.message);
+        const result = await response.json();
+        if (!result.success) {
+            console.error('Failed to create session');
+            alert('Failed to create session. Please refresh the page.');
+            return;
         }
-    });
-}
 
-function showError(message) {
-    const errorDiv = document.getElementById('connection-error');
-    errorDiv.textContent = message;
-    errorDiv.style.display = 'block';
-}
+        sessionId = result.session_id;
+        console.log('Session created:', sessionId);
 
-function hideConnectionModal() {
-    document.getElementById('connection-modal').style.display = 'none';
-    document.getElementById('app-container').style.display = 'block';
-}
+        // Setup terminals immediately
+        setupTerminals();
 
-// Initialize the main application
-function initializeApp() {
-    setupTerminals();
-    setupDisconnect();
-    connectWebSockets();
+        // Connect Gemini WebSocket
+        connectGeminiWebSocket();
+
+        // Setup SSH form handler
+        setupSSHForm();
+
+        // Setup resizer
+        setupResizer();
+    } catch (error) {
+        console.error('Failed to initialize app:', error);
+        alert('Failed to initialize application: ' + error.message);
+    }
 }
 
 // Setup both xterm.js terminals
@@ -131,13 +95,11 @@ function setupTerminals() {
 
         geminiTerminal.open(geminiContainer);
 
-        // Log container dimensions
-        const geminiRect = geminiContainer.getBoundingClientRect();
-        console.log('Gemini container dimensions:', geminiRect.width, 'x', geminiRect.height);
-
         // Write initial message
-        geminiTerminal.write('\x1b[36mGemini CLI Terminal\x1b[0m\r\n');
-        geminiTerminal.write('Connecting to Gemini...\r\n\r\n');
+        geminiTerminal.write('\x1b[36m┌─────────────────────────────────────┐\x1b[0m\r\n');
+        geminiTerminal.write('\x1b[36m│  Gemini CLI Terminal                │\x1b[0m\r\n');
+        geminiTerminal.write('\x1b[36m│  Initializing...                    │\x1b[0m\r\n');
+        geminiTerminal.write('\x1b[36m└─────────────────────────────────────┘\x1b[0m\r\n\r\n');
 
         // Focus the terminal to make it interactive
         geminiTerminal.focus();
@@ -146,12 +108,6 @@ function setupTerminals() {
         setTimeout(() => {
             geminiFitAddon.fit();
             console.log('Gemini terminal fitted:', geminiTerminal.cols, 'x', geminiTerminal.rows);
-            const xtermElement = geminiContainer.querySelector('.xterm');
-            if (xtermElement) {
-                const xtermRect = xtermElement.getBoundingClientRect();
-                console.log('Gemini xterm element dimensions:', xtermRect.width, 'x', xtermRect.height);
-            }
-            // Focus again after fit
             geminiTerminal.focus();
         }, 100);
 
@@ -170,7 +126,7 @@ function setupTerminals() {
             geminiTerminal.focus();
         });
 
-        // Setup SSH terminal
+        // Setup SSH terminal (initially hidden behind form)
         console.log('Creating SSH terminal...');
         sshTerminal = new Terminal({
             cursorBlink: true,
@@ -195,28 +151,10 @@ function setupTerminals() {
 
         sshTerminal.open(sshContainer);
 
-        // Log container dimensions
-        const sshRect = sshContainer.getBoundingClientRect();
-        console.log('SSH container dimensions:', sshRect.width, 'x', sshRect.height);
-
-        // Write initial message
-        sshTerminal.write('\x1b[32mSSH Terminal\x1b[0m\r\n');
-        sshTerminal.write('Connecting to SSH server...\r\n\r\n');
-
-        // Focus the terminal to make it interactive
-        sshTerminal.focus();
-
         // Fit after a short delay to ensure DOM is ready
         setTimeout(() => {
             sshFitAddon.fit();
             console.log('SSH terminal fitted:', sshTerminal.cols, 'x', sshTerminal.rows);
-            const xtermElement = sshContainer.querySelector('.xterm');
-            if (xtermElement) {
-                const xtermRect = xtermElement.getBoundingClientRect();
-                console.log('SSH xterm element dimensions:', xtermRect.width, 'x', xtermRect.height);
-            }
-            // Focus again after fit
-            sshTerminal.focus();
         }, 100);
 
         // Handle SSH terminal input
@@ -231,7 +169,9 @@ function setupTerminals() {
 
         // Focus SSH terminal when clicked
         sshContainer.addEventListener('click', () => {
-            sshTerminal.focus();
+            if (sshConnected) {
+                sshTerminal.focus();
+            }
         });
 
         // Handle window resize for both terminals
@@ -239,11 +179,9 @@ function setupTerminals() {
             console.log('Window resized, refitting terminals...');
             if (geminiFitAddon) {
                 geminiFitAddon.fit();
-                console.log('Gemini refitted:', geminiTerminal.cols, 'x', geminiTerminal.rows);
             }
             if (sshFitAddon) {
                 sshFitAddon.fit();
-                console.log('SSH refitted:', sshTerminal.cols, 'x', sshTerminal.rows);
             }
 
             if (geminiTerminalWs && geminiTerminalWs.readyState === WebSocket.OPEN) {
@@ -270,17 +208,16 @@ function setupTerminals() {
     }
 }
 
-// Setup WebSocket connections
-function connectWebSockets() {
+// Connect Gemini WebSocket
+function connectGeminiWebSocket() {
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
     const host = window.location.host;
 
-    // Connect Gemini terminal WebSocket
     geminiTerminalWs = new WebSocket(`${protocol}//${host}/ws/gemini-terminal/${sessionId}`);
 
     geminiTerminalWs.onopen = () => {
         console.log('Gemini terminal WebSocket connected');
-        geminiTerminal.write('\x1b[32m✓ Gemini CLI connected\x1b[0m\r\n');
+        geminiTerminal.write('\x1b[32m✓ Connected to Gemini CLI\x1b[0m\r\n\r\n');
     };
 
     geminiTerminalWs.onmessage = (event) => {
@@ -300,33 +237,6 @@ function connectWebSockets() {
     geminiTerminalWs.onclose = () => {
         console.log('Gemini terminal WebSocket closed');
         geminiTerminal.write('\x1b[33m✗ Connection closed\x1b[0m\r\n');
-    };
-
-    // Connect SSH terminal WebSocket
-    sshTerminalWs = new WebSocket(`${protocol}//${host}/ws/ssh-terminal/${sessionId}`);
-
-    sshTerminalWs.onopen = () => {
-        console.log('SSH terminal WebSocket connected');
-        sshTerminal.write('\x1b[32m✓ SSH terminal connected\x1b[0m\r\n');
-    };
-
-    sshTerminalWs.onmessage = (event) => {
-        const message = JSON.parse(event.data);
-        if (message.type === 'output') {
-            sshTerminal.write(message.data);
-        } else if (message.type === 'error') {
-            sshTerminal.write(`\x1b[31mError: ${message.message}\x1b[0m\r\n`);
-        }
-    };
-
-    sshTerminalWs.onerror = (error) => {
-        console.error('SSH terminal WebSocket error:', error);
-        sshTerminal.write('\x1b[31m✗ Connection error\x1b[0m\r\n');
-    };
-
-    sshTerminalWs.onclose = () => {
-        console.log('SSH terminal WebSocket closed');
-        sshTerminal.write('\x1b[33m✗ Connection closed\x1b[0m\r\n');
     };
 
     // Connect command approval WebSocket
@@ -350,6 +260,139 @@ function connectWebSockets() {
     commandApprovalWs.onclose = () => {
         console.log('Command approval WebSocket closed');
     };
+}
+
+// Setup SSH connection form
+function setupSSHForm() {
+    const form = document.getElementById('ssh-form');
+    const disconnectBtn = document.getElementById('disconnect-ssh-btn');
+
+    form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+
+        const formData = {
+            host: document.getElementById('host').value,
+            port: parseInt(document.getElementById('port').value),
+            username: document.getElementById('username').value,
+            password: document.getElementById('password').value || null,
+            private_key: document.getElementById('private-key').value || null,
+        };
+
+        try {
+            // Connect SSH
+            const sshResponse = await fetch('/api/ssh/connect', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(formData),
+            });
+
+            const sshResult = await sshResponse.json();
+
+            if (sshResult.success) {
+                // SSH connected successfully
+                sessionId = sshResult.session_id;
+                sshConnected = true;
+
+                // Hide the form
+                document.getElementById('ssh-connection-form').style.display = 'none';
+
+                // Update status
+                updateSSHStatus('connected');
+
+                // Connect SSH WebSocket
+                connectSSHWebSocket();
+
+                // Show disconnect button
+                disconnectBtn.style.display = 'block';
+
+                // Focus SSH terminal
+                sshTerminal.focus();
+            } else {
+                showSSHError(sshResult.error || 'SSH connection failed');
+            }
+        } catch (error) {
+            showSSHError('Failed to connect: ' + error.message);
+        }
+    });
+
+    disconnectBtn.addEventListener('click', () => {
+        disconnectSSH();
+    });
+}
+
+// Connect SSH WebSocket
+function connectSSHWebSocket() {
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const host = window.location.host;
+
+    sshTerminalWs = new WebSocket(`${protocol}//${host}/ws/ssh-terminal/${sessionId}`);
+
+    sshTerminalWs.onopen = () => {
+        console.log('SSH terminal WebSocket connected');
+        sshTerminal.write('\x1b[32m✓ SSH connection established\x1b[0m\r\n\r\n');
+    };
+
+    sshTerminalWs.onmessage = (event) => {
+        const message = JSON.parse(event.data);
+        if (message.type === 'output') {
+            sshTerminal.write(message.data);
+        } else if (message.type === 'error') {
+            sshTerminal.write(`\x1b[31mError: ${message.message}\x1b[0m\r\n`);
+        }
+    };
+
+    sshTerminalWs.onerror = (error) => {
+        console.error('SSH terminal WebSocket error:', error);
+        sshTerminal.write('\x1b[31m✗ Connection error\x1b[0m\r\n');
+    };
+
+    sshTerminalWs.onclose = () => {
+        console.log('SSH terminal WebSocket closed');
+        sshTerminal.write('\x1b[33m✗ SSH connection closed\x1b[0m\r\n\r\n');
+        sshConnected = false;
+        updateSSHStatus('disconnected');
+        // Show the form again
+        document.getElementById('ssh-connection-form').style.display = 'flex';
+        document.getElementById('disconnect-ssh-btn').style.display = 'none';
+    };
+}
+
+// Disconnect SSH
+function disconnectSSH() {
+    if (sshTerminalWs) {
+        sshTerminalWs.close();
+    }
+    sshConnected = false;
+    sshTerminal.clear();
+    updateSSHStatus('disconnected');
+    document.getElementById('ssh-connection-form').style.display = 'flex';
+    document.getElementById('disconnect-ssh-btn').style.display = 'none';
+}
+
+// Update SSH status badge
+function updateSSHStatus(status) {
+    const statusBadge = document.getElementById('ssh-status');
+    if (status === 'connected') {
+        statusBadge.textContent = 'SSH: Connected';
+        statusBadge.className = 'status-badge connected';
+    } else {
+        statusBadge.textContent = 'SSH: Disconnected';
+        statusBadge.className = 'status-badge disconnected';
+    }
+}
+
+// Show SSH error
+function showSSHError(message) {
+    const errorDiv = document.getElementById('ssh-error');
+    errorDiv.textContent = message;
+    errorDiv.style.display = 'block';
+
+    // Hide error after 5 seconds
+    setTimeout(() => {
+        errorDiv.style.display = 'none';
+    }, 5000);
 }
 
 // Command approval system
@@ -380,24 +423,6 @@ function approveCommand(approved) {
 
     document.getElementById('command-approval-modal').style.display = 'none';
     pendingCommand = null;
-}
-
-// Setup disconnect functionality
-function setupDisconnect() {
-    document.getElementById('disconnect-btn').addEventListener('click', () => {
-        if (geminiTerminalWs) geminiTerminalWs.close();
-        if (sshTerminalWs) sshTerminalWs.close();
-        if (commandApprovalWs) commandApprovalWs.close();
-        if (geminiTerminal) geminiTerminal.dispose();
-        if (sshTerminal) sshTerminal.dispose();
-
-        document.getElementById('app-container').style.display = 'none';
-        document.getElementById('connection-modal').style.display = 'flex';
-
-        // Reset form
-        document.getElementById('ssh-form').reset();
-        document.getElementById('connection-error').style.display = 'none';
-    });
 }
 
 // Setup pane resizer

--- a/static/index.html
+++ b/static/index.html
@@ -7,42 +7,11 @@
     <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
-    <div id="connection-modal" class="modal">
-        <div class="modal-content">
-            <h2>Connect to SSH Server</h2>
-            <form id="ssh-form">
-                <div class="form-group">
-                    <label for="host">Host:</label>
-                    <input type="text" id="host" name="host" required placeholder="example.com">
-                </div>
-                <div class="form-group">
-                    <label for="port">Port:</label>
-                    <input type="number" id="port" name="port" value="22" required>
-                </div>
-                <div class="form-group">
-                    <label for="username">Username:</label>
-                    <input type="text" id="username" name="username" required>
-                </div>
-                <div class="form-group">
-                    <label for="password">Password:</label>
-                    <input type="password" id="password" name="password" placeholder="Leave empty if using key">
-                </div>
-                <div class="form-group">
-                    <label for="private-key">Private Key (optional):</label>
-                    <textarea id="private-key" name="private-key" rows="4" placeholder="Paste private key here"></textarea>
-                </div>
-                <div id="connection-error" class="error" style="display: none;"></div>
-                <button type="submit" class="btn-primary">Connect</button>
-            </form>
-        </div>
-    </div>
-
-    <div id="app-container" style="display: none;">
+    <div id="app-container">
         <div class="header">
             <h1>🤖 Gemini Co-CLI</h1>
             <div class="header-info">
-                <span id="connection-status">Connected</span>
-                <button id="disconnect-btn" class="btn-secondary">Disconnect</button>
+                <span id="ssh-status" class="status-badge disconnected">SSH: Disconnected</span>
             </div>
         </div>
 
@@ -61,6 +30,38 @@
                     <h2>💻 SSH Terminal</h2>
                 </div>
                 <div id="ssh-terminal"></div>
+
+                <!-- SSH Connection Form (shown initially) -->
+                <div id="ssh-connection-form" class="ssh-form-container">
+                    <h3>Connect to SSH Server</h3>
+                    <form id="ssh-form">
+                        <div class="form-group">
+                            <label for="host">Host:</label>
+                            <input type="text" id="host" name="host" required placeholder="example.com">
+                        </div>
+                        <div class="form-group">
+                            <label for="port">Port:</label>
+                            <input type="number" id="port" name="port" value="22" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="username">Username:</label>
+                            <input type="text" id="username" name="username" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="password">Password:</label>
+                            <input type="password" id="password" name="password" placeholder="Leave empty if using key">
+                        </div>
+                        <div class="form-group">
+                            <label for="private-key">Private Key (optional):</label>
+                            <textarea id="private-key" name="private-key" rows="3" placeholder="Paste private key here"></textarea>
+                        </div>
+                        <div id="ssh-error" class="error" style="display: none;"></div>
+                        <div class="form-actions">
+                            <button type="submit" class="btn-primary">Connect</button>
+                            <button type="button" id="disconnect-ssh-btn" class="btn-secondary" style="display: none;">Disconnect</button>
+                        </div>
+                    </form>
+                </div>
             </div>
         </div>
     </div>

--- a/static/style.css
+++ b/static/style.css
@@ -32,12 +32,21 @@ body {
     gap: 1rem;
 }
 
-#connection-status {
+.status-badge {
     padding: 0.5rem 1rem;
-    background: #1e4620;
-    color: #4ade80;
     border-radius: 4px;
     font-size: 0.875rem;
+    font-weight: 600;
+}
+
+.status-badge.connected {
+    background: #1e4620;
+    color: #4ade80;
+}
+
+.status-badge.disconnected {
+    background: #4a1e1e;
+    color: #f87171;
 }
 
 .modal {
@@ -164,6 +173,7 @@ body {
 .terminal-pane {
     flex: 1;
     min-width: 300px;
+    position: relative;
 }
 
 .pane-header {
@@ -261,6 +271,43 @@ body {
 #gemini-terminal .xterm,
 #ssh-terminal .xterm {
     cursor: text;
+}
+
+/* SSH Connection Form Overlay */
+.ssh-form-container {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(15, 15, 15, 0.98);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem;
+    z-index: 10;
+}
+
+.ssh-form-container h3 {
+    color: #fff;
+    margin-bottom: 1.5rem;
+    font-size: 1.25rem;
+}
+
+.ssh-form-container form {
+    width: 100%;
+    max-width: 400px;
+}
+
+.ssh-form-container .form-actions {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+}
+
+.ssh-form-container .form-actions button {
+    flex: 1;
 }
 
 .command-preview {


### PR DESCRIPTION
Terminals failed to accept keyboard input due to missing focus in XTerm.js, which requires explicit focus calls for event capture. Changes in app.js add terminal.focus() on opening, after fit() resizing, and click handlers on containers to enable typing. CSS adds cursor: text to containers and .xterm elements for visual input feedback.[1]

## UI Flow Restructuring

index.html removes modals, shows both terminals immediately without display: none, and overlays SSH form in the right pane. CSS updates use .status-badge for connection states, positions .ssh-form-container absolutely over the relative .terminal-pane, and hides the form post-connection. app.js initializes everything on load, auto-starts Gemini WebSocket and terminal, manages independent SSH connect/disconnect with status updates and terminal clearing.

## New User Flow

Page load renders both terminals: Gemini CLI runs persistently in the left pane, while SSH pane shows overlay form. User connects via form (hides overlay, activates terminal), disconnects (re-shows form, clears terminal), and Gemini remains active throughout. This aligns with the split-pane mockup for immediate dual-terminal visibility and interaction.