### PR TITLE
Fix Gemini CLI stdin error by using PTY for proper terminal emulation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,9 @@ dotenvy = "0.15"
 # UUID for session management
 uuid = { version = "1.0", features = ["v4", "serde"] }
 
+# PTY for proper terminal emulation
+portable-pty = "0.8"
+
 # Pin base64ct to version compatible with Rust 1.83
 [dependencies.base64ct]
 version = "=1.6.0"

--- a/src/gemini.rs
+++ b/src/gemini.rs
@@ -1,48 +1,68 @@
 use anyhow::{Context, Result};
-use std::process::Stdio;
-use tokio::io::{AsyncBufReadExt, BufReader};
-use tokio::process::{Child, Command};
-use tokio::sync::mpsc;
+use portable_pty::{CommandBuilder, PtySize};
+use std::io::{Read, Write};
+use std::sync::Arc;
+use tokio::sync::Mutex;
 
-/// Manages an interactive Gemini CLI terminal session
+/// Manages an interactive Gemini CLI terminal session using PTY
 pub struct GeminiTerminal {
-    process: Child,
+    pty_pair: Arc<Mutex<portable_pty::PtyPair>>,
+    _child: Box<dyn portable_pty::Child + Send>,
 }
 
 impl GeminiTerminal {
-    /// Spawn a new interactive Gemini CLI process
-    pub async fn spawn() -> Result<Self> {
-        let process = Command::new("gemini")
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
+    /// Spawn a new interactive Gemini CLI process with PTY
+    pub fn spawn() -> Result<Self> {
+        let pty_system = portable_pty::native_pty_system();
+
+        // Create a PTY with initial size
+        let pty_pair = pty_system
+            .openpty(PtySize {
+                rows: 24,
+                cols: 80,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .context("Failed to create PTY")?;
+
+        // Build command to run gemini CLI
+        let cmd = CommandBuilder::new("gemini");
+
+        // Spawn the process in the PTY
+        let child = pty_pair
+            .slave
+            .spawn_command(cmd)
             .context("Failed to spawn gemini CLI. Is it installed?")?;
 
-        Ok(Self { process })
+        Ok(Self {
+            pty_pair: Arc::new(Mutex::new(pty_pair)),
+            _child: child,
+        })
     }
 
-    /// Get stdin handle for writing to Gemini
-    pub fn stdin(&mut self) -> Option<tokio::process::ChildStdin> {
-        self.process.stdin.take()
+    /// Get reader for PTY output
+    pub fn get_reader(&self) -> Box<dyn Read + Send> {
+        let pty = self.pty_pair.blocking_lock();
+        pty.master.try_clone_reader().expect("Failed to clone reader")
     }
 
-    /// Get stdout handle for reading from Gemini
-    pub fn stdout(&mut self) -> Option<tokio::process::ChildStdout> {
-        self.process.stdout.take()
+    /// Take writer for PTY input (can only be called once)
+    pub fn take_writer(&self) -> Box<dyn Write + Send> {
+        let mut pty = self.pty_pair.blocking_lock();
+        pty.master.take_writer().expect("Failed to take writer")
     }
 
-    /// Get stderr handle for reading errors
-    pub fn stderr(&mut self) -> Option<tokio::process::ChildStderr> {
-        self.process.stderr.take()
-    }
-
-    /// Kill the Gemini process
-    pub async fn kill(mut self) -> Result<()> {
-        self.process
-            .kill()
-            .await
-            .context("Failed to kill gemini process")?;
+    /// Resize the PTY
+    pub fn resize(&self, cols: u16, rows: u16) -> Result<()> {
+        let pty = self.pty_pair.blocking_lock();
+        pty.master
+            .resize(PtySize {
+                rows,
+                cols,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .context("Failed to resize PTY")?;
         Ok(())
     }
 }
@@ -58,22 +78,6 @@ pub fn extract_command(text: &str) -> Option<String> {
         }
     }
     None
-}
-
-/// Monitor Gemini output for commands and send them to a channel
-pub async fn monitor_for_commands(
-    mut stdout: tokio::process::ChildStdout,
-    tx: mpsc::UnboundedSender<String>,
-) {
-    let reader = BufReader::new(&mut stdout);
-    let mut lines = reader.lines();
-
-    while let Ok(Some(line)) = lines.next_line().await {
-        // Check each line for EXECUTE commands
-        if let Some(command) = extract_command(&line) {
-            let _ = tx.send(command);
-        }
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Problem:
Gemini CLI was showing "Error: No input provided via stdin" repeatedly because it detected piped stdin and expected immediate input, but we wanted interactive terminal mode.

Solution - Use Pseudo-Terminal (PTY):
- Added portable-pty dependency to Cargo.toml
- Rewrote gemini.rs to use PTY instead of pipes
- PTY emulates a real terminal, allowing Gemini CLI to run interactively
- Gemini CLI now sees a proper TTY and enters interactive mode

Changes:

1. Cargo.toml:
   - Added portable-pty = "0.8" for PTY support

2. src/gemini.rs (Complete rewrite):
   - Use portable_pty::PtyPair instead of tokio::process::Command
   - spawn() creates PTY with 80x24 initial size
   - get_reader() returns Box<dyn Read + Send> for PTY output
   - take_writer() returns Box<dyn Write + Send> for PTY input
   - resize() supports dynamic terminal resizing
   - Wrapped pty_pair in Arc<Mutex<>> for thread-safe access

3. src/websocket.rs:
   - Updated gemini_terminal_connection to use PTY reader/writer
   - Use spawn_blocking for synchronous I/O operations
   - Read from PTY in 4KB chunks, send to WebSocket
   - Handle WebSocket input, write to PTY
   - Removed AsyncBufReadExt/AsyncWriteExt (not needed for PTY)
   - Fixed tokio::select! move errors with &mut references

Result:
Gemini CLI now runs in proper interactive mode without stdin errors. Both Gemini and SSH terminals are fully functional and interactive.